### PR TITLE
Fix: Reorder sidebar items to 3 top, 2 bottom

### DIFF
--- a/WindowsTroubleShooter/View/StartView.xaml
+++ b/WindowsTroubleShooter/View/StartView.xaml
@@ -46,17 +46,31 @@
 
 
             <Border Grid.Row="1" Grid.Column="0"
-                    Background="#2b2b2b"
-                    CornerRadius="0,0,0,8">
-                <StackPanel Width="55">
-                    
-                    <Button Style="{StaticResource SideBarButtonStyle}" Content="&#xE80F;" FontFamily="Segoe MDL2 Assets" Margin="0,0,0,0" Command="{Binding SwitchToDashboardCommand}"/>
-                    <Button Style="{StaticResource SideBarButtonStyle}" Content="&#xEA37;" FontFamily="Segoe MDL2 Assets" Margin="0,10,0,0" Command="{Binding SwitchToProblemListCommand}"/>
-                    <Button Style="{StaticResource SideBarButtonStyle}" Content="&#xE710;" FontFamily="Segoe MDL2 Assets" Margin="0,10,0,0"/>
-                    <Button Style="{StaticResource SideBarButtonStyle}" Content="&#xE713;" FontFamily="Segoe MDL2 Assets" Margin="0,0,0,0" Command="{Binding SwitchToSettingsCommand}"/>
-                    <Button Style="{StaticResource SideBarButtonStyle}" Content="&#xE946;" FontFamily="Segoe MDL2 Assets" Margin="0,10,0,0" />
-                </StackPanel>
+             Background="#2b2b2b"
+             CornerRadius="0,0,0,8">
+                <Grid Width="55">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <!-- For the separator -->
+                            <RowDefinition Height="*"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+
+                    <Button Grid.Row="0" Style="{StaticResource SideBarButtonStyle}" Content="&#xE80F;" FontFamily="Segoe MDL2 Assets" Margin="0,0,0,0" Command="{Binding SwitchToDashboardCommand}"/>
+                    <Button Grid.Row="1" Style="{StaticResource SideBarButtonStyle}" Content="&#xEA37;" FontFamily="Segoe MDL2 Assets" Margin="0,10,0,0" Command="{Binding SwitchToProblemListCommand}"/>
+                    <Button Grid.Row="2" Style="{StaticResource SideBarButtonStyle}" Content="&#xE710;" FontFamily="Segoe MDL2 Assets" Margin="0,10,0,0"/>
+
+                    <Border Grid.Row="3" Height="1" Background="#444444" Margin="0,15"/>
+
+                    <Button Grid.Row="5" VerticalAlignment="Bottom" Style="{StaticResource SideBarButtonStyle}" Content="&#xE713;" FontFamily="Segoe MDL2 Assets" Margin="0,0,0,0" Command="{Binding SwitchToSettingsCommand}"/>
+                    <Button Grid.Row="6" VerticalAlignment="Bottom" Style="{StaticResource SideBarButtonStyle}" Content="&#xE946;" FontFamily="Segoe MDL2 Assets" Margin="0,10,0,0" />
+                </Grid>
             </Border>
+
 
             <Grid Grid.Row="1" Grid.Column="1" Margin="30 0 30 0">
                 <ContentControl Content="{Binding CurrentUserControl}"/>


### PR DESCRIPTION
Reorder sidebar items to 3 top, 2 bottom by replacing the stackpanel with a grid