### PR TITLE
feat: Implement automatic saving for network drive changes and move r…

### DIFF
--- a/WindowsTroubleShooter/View/SettingsView.xaml
+++ b/WindowsTroubleShooter/View/SettingsView.xaml
@@ -75,14 +75,37 @@
                         </StackPanel>
 
                         <TextBlock Text="Configured Network Drives:" Margin="0,10,0,5"/>
-                        <ListBox ItemsSource="{Binding ConfiguredNetworkDrives}" Background="#333333" Foreground="#dddddd" BorderBrush="#555555" BorderThickness="1" MaxHeight="100">
+                        <ListBox ItemsSource="{Binding ConfiguredNetworkDrives}"
+                             Background="#333333"
+                             Foreground="#dddddd"
+                             BorderBrush="#555555"
+                             BorderThickness="1"
+                             MaxHeight="100"
+                             HorizontalContentAlignment="Stretch">
                             <ListBox.ItemTemplate>
                                 <DataTemplate>
-                                    <StackPanel Orientation="Horizontal">
-                                        <TextBlock Text="{Binding Key}" FontWeight="SemiBold"/>
-                                        <TextBlock Text=" - "/>
-                                        <TextBlock Text="{Binding Value}"/>
-                                    </StackPanel>
+                                    <Grid Margin="0,2">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+
+                                        <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center">
+                                            <TextBlock Text="{Binding Key}" FontWeight="SemiBold"/>
+                                            <TextBlock Text=" - "/>
+                                            <TextBlock Text="{Binding Value}"/>
+                                        </StackPanel>
+
+                                        <Button Grid.Column="1"
+                                            Content="Remove"
+                                            Style="{StaticResource ButtonStyle}"  
+                                            Margin="10,0,0,0"        
+                                            Padding="5,1"           
+                                            FontSize="11"           
+                                            VerticalAlignment="Center" 
+                                            Command="{Binding DataContext.RemoveNetworkDriveCommand, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}}"
+                                            CommandParameter="{Binding Key}"/>
+                                    </Grid>
                                 </DataTemplate>
                             </ListBox.ItemTemplate>
                         </ListBox>

--- a/WindowsTroubleShooter/ViewModel/SettingsViewModel.cs
+++ b/WindowsTroubleShooter/ViewModel/SettingsViewModel.cs
@@ -18,7 +18,14 @@ namespace WindowsTroubleShooter.ViewModel
         public Dictionary<string, string> ConfiguredNetworkDrives
         {
             get => _configuredNetworkDrives;
-            set => SetProperty(ref _configuredNetworkDrives, value);
+            set
+            {
+                if (SetProperty(ref _configuredNetworkDrives, value))
+                {
+                    SaveSettings();
+                    UpdateAvailableDriveLetters();
+                }
+            }
         }
 
         private string _newDriveLetter;
@@ -130,7 +137,7 @@ namespace WindowsTroubleShooter.ViewModel
             _alternateDns = string.Empty;
             _pauseUpdates = false;
             _activeHoursStart = "09:00"; // Default start time
-            _activeHoursEnd = "17:00";   // Default end time
+            _activeHoursEnd = "17:00";    // Default end time
 
             // Todo: implement how AvailableOutputDevices are fetched
             // ex _availableOutputDevices = GetAvailableSoundDevices();
@@ -138,14 +145,15 @@ namespace WindowsTroubleShooter.ViewModel
 
         private void AddNetworkDrive()
         {
-            var updatedDrives = new Dictionary<string, string>(ConfiguredNetworkDrives);
-            updatedDrives.Add(NewDriveLetter, NewDrivePath);
-            ConfiguredNetworkDrives = updatedDrives;
+            if (CanAddNetworkDrive())
+            {
+                var updatedDrives = new Dictionary<string, string>(ConfiguredNetworkDrives);
+                updatedDrives.Add(NewDriveLetter, NewDrivePath);
+                ConfiguredNetworkDrives = updatedDrives; // This will trigger SaveSettings and UpdateAvailableDriveLetters
 
-            AvailableDriveLetters.Remove(NewDriveLetter);
-
-            NewDriveLetter = null;
-            NewDrivePath = string.Empty;
+                NewDriveLetter = null;
+                NewDrivePath = string.Empty;
+            }
         }
 
         private bool CanAddNetworkDrive()
@@ -161,15 +169,7 @@ namespace WindowsTroubleShooter.ViewModel
             var updatedDrives = new Dictionary<string, string>(ConfiguredNetworkDrives);
             if (updatedDrives.Remove(driveLetterToRemove))
             {
-                ConfiguredNetworkDrives = updatedDrives;
-
-                if (!AvailableDriveLetters.Contains(driveLetterToRemove))
-                {
-                    AvailableDriveLetters.Add(driveLetterToRemove);
-                    var sortedLetters = AvailableDriveLetters.OrderBy(l => l).ToList();
-                    AvailableDriveLetters.Clear();
-                    foreach (var l in sortedLetters) AvailableDriveLetters.Add(l);
-                }
+                ConfiguredNetworkDrives = updatedDrives; // This will trigger SaveSettings and UpdateAvailableDriveLetters
             }
         }
 
@@ -265,7 +265,6 @@ namespace WindowsTroubleShooter.ViewModel
             }
         }
 
-        
 
         // --- Helper Methods ---
         private void UpdateAvailableDriveLetters()


### PR DESCRIPTION
…emove buttonThis commit introduces automatic saving of network drive configurations whenever a drive is added or removed. This eliminates the need for a separate Save button for these changes.Additionally, the Remove button for network drives has been moved to the right for better visual organization.