### PR TITLE
Fix: Enable navigation from Dashboard to Problem List when click see all

### DIFF
--- a/WindowsTroubleShooter/View/DashboardView.xaml
+++ b/WindowsTroubleShooter/View/DashboardView.xaml
@@ -94,6 +94,7 @@
         <Button Grid.Row="2"
                 HorizontalAlignment="Right"
                 Style="{StaticResource ButtonStyle}"
+                Command="{Binding SwitchToProblemListCommand}"
                 Margin="0,15,20,5" Height="25" Width="100">
             <Button.ContentTemplate>
                 <DataTemplate>

--- a/WindowsTroubleShooter/ViewModel/DashboardViewModel.cs
+++ b/WindowsTroubleShooter/ViewModel/DashboardViewModel.cs
@@ -6,7 +6,9 @@ using System.Net.NetworkInformation;
 using WindowsTroubleShooter.Interfaces;
 using WindowsTroubleShooter.Model;
 using System.Linq;
-using System.Collections.Generic; 
+using System.Collections.Generic;
+using System.Windows.Input;
+using WindowsTroubleShooter.Helpers.Commands;
 
 namespace WindowsTroubleShooter.ViewModel
 {
@@ -25,7 +27,8 @@ namespace WindowsTroubleShooter.ViewModel
         private ObservableCollection<HistoryEntryModel> _historyEntries; 
         private ObservableCollection<string> _selectedIssues = new ObservableCollection<string>();
 
-        
+        public ICommand SwitchToProblemListCommand { get; set; }
+
 
         // --- Public Properties Binding ---
 
@@ -95,7 +98,16 @@ namespace WindowsTroubleShooter.ViewModel
             LoadVersionInfo();
 
             // TODO: Implenment timer or event listener call UpdateSystemStatus() in a span time
-            
+
+            // Navigation commands
+            SwitchToProblemListCommand = new RelayCommand(SwitchToProblemList);
+
+        }
+
+        public event EventHandler RequestNavigateToProblemList;
+        private void SwitchToProblemList(object obj)
+        {
+            RequestNavigateToProblemList?.Invoke(this, EventArgs.Empty);
         }
 
         // --- Data Loading Methods ---

--- a/WindowsTroubleShooter/ViewModel/StartViewModel.cs
+++ b/WindowsTroubleShooter/ViewModel/StartViewModel.cs
@@ -35,7 +35,17 @@ namespace WindowsTroubleShooter.ViewModel
         public UserControl CurrentUserControl
         {
             get { return _currentUserControl; }
-            set { SetProperty(ref (_currentUserControl), value); }
+            set
+            {
+                SetProperty(ref _currentUserControl, value);
+                // Subscribe to the event whenever CurrentUserControl becomes a DashboardView
+                if (_currentUserControl is DashboardView dashboardView && dashboardView.DataContext is DashboardViewModel dashboardViewModel)
+                {
+                    dashboardViewModel.RequestNavigateToProblemList -= DashboardViewModel_RequestNavigateToProblemList; // Unsubscribe first to avoid multiple subscriptions
+                    dashboardViewModel.RequestNavigateToProblemList += DashboardViewModel_RequestNavigateToProblemList;
+
+                }
+            }
         } 
 
         public StartViewModel() 
@@ -49,6 +59,14 @@ namespace WindowsTroubleShooter.ViewModel
             SwitchToProblemListCommand = new RelayCommand(SwitchToProblemList);
             SwitchToSettingsCommand = new RelayCommand(SwitchToSettings);
             
+            if (CurrentUserControl is DashboardView dashboardView)
+        {
+            if (dashboardView.DataContext is DashboardViewModel dashboardViewModel)
+            {
+                dashboardViewModel.RequestNavigateToProblemList += DashboardViewModel_RequestNavigateToProblemList;
+            }
+        }
+
         }
 
         private void SwitchToSettings()
@@ -88,6 +106,12 @@ namespace WindowsTroubleShooter.ViewModel
                     UpdateSelectedView(CurrentUserControl);
                     
             }
+        }
+
+        private void DashboardViewModel_RequestNavigateToProblemList(object sender, EventArgs e)
+        {
+            CurrentUserControl = new ProblemListView();
+            UpdateSelectedView(CurrentUserControl);
         }
 
         private void UpdateSelectedView(UserControl currentControl)


### PR DESCRIPTION
The "See all" button on the Dashboard was not triggering navigation to the Problem List. This commit implements event-based click where the `DashboardViewModel` raises an event to the startviewmodel