### PR TITLE
Refractor: application now requires to run as admin

### DIFF
--- a/WindowsTroubleShooter/Model/InternetTroubleshooter.cs
+++ b/WindowsTroubleShooter/Model/InternetTroubleshooter.cs
@@ -13,7 +13,8 @@ namespace WindowsTroubleShooter.Model
         private const string CheckAdaptersScriptPath = @"Scripts\\Internet\\IsNetworkAdaptersAvailable.ps1"; 
         private const string RefreshAdaptersScriptPath = @"Scripts\\Internet\\RefreshNetworkAdapter.ps1";
 
-
+        private string _networkadapter;
+        private List<TroubleshootingStep> _troubleshootingSteps;
 
         public InternetTroubleshooter()
         {
@@ -26,59 +27,38 @@ namespace WindowsTroubleShooter.Model
                 "Refreshing Network Adapter",
                 "Network Reset"
             };
-        }
 
-       
+            _troubleshootingSteps = new List<TroubleshootingStep>
+            {
+                new TroubleshootingStep {
+                    Description = "Checking Network Adapters Availability",
+                    ScriptPath = CheckAdaptersScriptPath,
+                    IsCritical = true // If adapters aren't available, can't proceed
+                },
+                new TroubleshootingStep {
+                    Description = "Refreshing Network Adapters",
+                    ScriptPath = RefreshAdaptersScriptPath,
+                    IsCritical = false
+                } 
+            };
+        }
 
         public override async Task<string> RunDiagnosticsAsync()
         {
-            StatusMessage = "Checking Internet Connection...";
-            await Task.Delay(2000);
 
-            var (output, error, exitCode) = await ExecutePowerShellScriptAsync(CheckAdaptersScriptPath);
-
-            if (exitCode != 0)
+            foreach (var step in _troubleshootingSteps)
             {
-                Debug.WriteLine($"PowerShell Execution Failed!");
-                Debug.WriteLine($"Exit Code: {exitCode}");
-                Debug.WriteLine($"Standard Output: {(string.IsNullOrWhiteSpace(output) ? "(empty)" : output)}");
-                Debug.WriteLine($"Standard Error: {(string.IsNullOrWhiteSpace(error) ? "(empty)" : error)}");
 
-                StatusMessage = $"Error: {exitCode} | Output: {output} | Error: {error}";
+                
+                (IsFixed, ResolutionMessage) =  await ExecuteTroubleshootingStepAsync(step);
 
-                await Task.Delay(2000);
-                return $"Error checking network adapters: {error}";
+                
+                if (step.IsCritical && !IsFixed)
+                    break;
+
+
             }
-
-            StatusMessage = "Refreshing Network Adapter...";
-            await Task.Delay(2000);
-
-            var (refreshOutput, refreshError, refreshExitCode) = await ExecutePowerShellScriptAsync(RefreshAdaptersScriptPath);
-
-            if (refreshExitCode != 0)
-            {
-                Debug.WriteLine($"PowerShell Execution Failed!");
-                Debug.WriteLine($"Exit Code: {refreshExitCode}");
-                Debug.WriteLine($"Standard Output: {(string.IsNullOrWhiteSpace(refreshOutput) ? "(empty)" : refreshOutput)}");
-                Debug.WriteLine($"Standard Error: {(string.IsNullOrWhiteSpace(refreshError) ? "(empty)" : refreshError)}");
-
-                StatusMessage = $"Error: Please try again later";
-                return $"Error refreshing network adapters: {refreshError}";
-            }
-
-            StatusMessage = "Network Reset...";
-            await Task.Delay(2000);
-
-            IsFixed = true; // Assume fix worked for now
-
-            if (IsFixed)
-            {
-                StatusMessage = "Internet Connection Fixed!";
-                await Task.Delay(2000);
-                return "Internet Connection Fixed";
-            }
-
-            return "Internet Connection failed";
+            return ResolutionMessage;
         }
     }
 }

--- a/WindowsTroubleShooter/Scripts/Internet/IsNetworkAdaptersAvailable.ps1
+++ b/WindowsTroubleShooter/Scripts/Internet/IsNetworkAdaptersAvailable.ps1
@@ -2,7 +2,9 @@ $adapter = Get-NetAdapter | Where-Object {$_.Status -eq 'Up' -and $_.HardwareInt
 
 if($adapter.Count -eq 0){
 
-	Write-Output "Not active network adapters found"
+	Write-Output "No active network adapters found"
 	exit 1 
 }
-Write-Output "Active network adapters found: $adapter"
+
+Write-Output "Active network adapters found: $($adapter.name -join ', ')"
+

--- a/WindowsTroubleShooter/Scripts/Internet/RefreshNetworkAdapter.ps1
+++ b/WindowsTroubleShooter/Scripts/Internet/RefreshNetworkAdapter.ps1
@@ -1,16 +1,11 @@
+#Get Adapter
+$adapter = Get-NetAdapter | Where-Object {$_.Status -eq 'Up' -and $_.HardwareInterface -eq $true}
+$adapterName = $adapter.Name
 
-# Geting all network adapters
-$networkAdapters = Get-NetAdapter
+Disable-NetAdapter -Name $adapterName -Confirm:$false
+Start-Sleep -Seconds 1
 
-foreach ($adapter in $networkAdapters) {
-    # Disable the network adapter
-    Disable-NetAdapter -Name $adapter.Name -Confirm:$false
-    Write-Output "Network adapter '$($adapter.Name)' disabled."
+# Enable the adapter
+Enable-NetAdapter -Name $adapterName -Confirm:$false
 
-    # Wait for a few seconds
-    Start-Sleep -Seconds 5
-
-    # Reenable the network adapter
-    Enable-NetAdapter -Name $adapter.Name -Confirm:$false
-    Write-Output "Network adapter '$($adapter.Name)' enabled"
-}
+Write-Output "Network adapter '$adapterName' restarted successfully."

--- a/WindowsTroubleShooter/WindowsTroubleShooter.csproj
+++ b/WindowsTroubleShooter/WindowsTroubleShooter.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net6.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
 
   <ItemGroup>

--- a/WindowsTroubleShooter/app.manifest
+++ b/WindowsTroubleShooter/app.manifest
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <!-- UAC Manifest Options
+             If you want to change the Windows User Account Control level replace the 
+             requestedExecutionLevel node with one of the following.
+
+        <requestedExecutionLevel  level="asInvoker" uiAccess="false" />
+        <requestedExecutionLevel  level="requireAdministrator" uiAccess="false" />
+        <requestedExecutionLevel  level="highestAvailable" uiAccess="false" />
+
+            Specifying requestedExecutionLevel element will disable file and registry virtualization. 
+            Remove this element if your application requires this virtualization for backwards
+            compatibility.
+        -->
+        <requestedExecutionLevel level="requireAdministrator" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- A list of the Windows versions that this application has been tested on
+           and is designed to work with. Uncomment the appropriate elements
+           and Windows will automatically select the most compatible environment. -->
+
+      <!-- Windows Vista -->
+      <!--<supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />-->
+
+      <!-- Windows 7 -->
+      <!--<supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />-->
+
+      <!-- Windows 8 -->
+      <!--<supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />-->
+
+      <!-- Windows 8.1 -->
+      <!--<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />-->
+
+      <!-- Windows 10 -->
+      <!--<supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />-->
+
+    </application>
+  </compatibility>
+
+  <!-- Indicates that the application is DPI-aware and will not be automatically scaled by Windows at higher
+       DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
+       to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
+       also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. 
+       
+       Makes the application long-path aware. See https://docs.microsoft.com/windows/win32/fileio/maximum-file-path-limitation -->
+  <!--
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+    </windowsSettings>
+  </application>
+  -->
+
+  <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
+  <!--
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type="win32"
+          name="Microsoft.Windows.Common-Controls"
+          version="6.0.0.0"
+          processorArchitecture="*"
+          publicKeyToken="6595b64144ccf1df"
+          language="*"
+        />
+    </dependentAssembly>
+  </dependency>
+  -->
+
+</assembly>


### PR DESCRIPTION
Refractor: application now requires to run as admin. Due to some restrictions. Avoided repetitive code on both the basedtroubleshooter and internettroubleshooter. 